### PR TITLE
kaminari を使って書籍一覧にページング処理を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,3 +54,6 @@ gem "carrierwave"
 gem "rubocop", "~> 0.85.0"
 gem "rubocop-performance", "~>1.6.0"
 gem "rubocop-rails", "~>2.6.0"
+
+# pagination
+gem "kaminari", "~> 1.2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,21 @@ gem "turbolinks", "~> 5"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.2", require: false
 
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "awesome_print"
+
+gem "carrierwave"
+
+# code formatter
+gem "rubocop", "~> 0.85.0"
+gem "rubocop-performance", "~>1.6.0"
+gem "rubocop-rails", "~>2.6.0"
+
+# pagination
+gem "kaminari", "~> 1.2.0"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
@@ -42,18 +57,3 @@ group :test do
   # Easy installation and use of web drivers to run system tests with browsers
   gem "webdrivers"
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-gem "awesome_print"
-
-gem "carrierwave"
-
-# code formatter
-gem "rubocop", "~> 0.85.0"
-gem "rubocop-performance", "~>1.6.0"
-gem "rubocop-rails", "~>2.6.0"
-
-# pagination
-gem "kaminari", "~> 1.2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -24,14 +24,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem "awesome_print"
-
 gem "carrierwave"
-
-# code formatter
-gem "rubocop", "~> 0.85.0"
-gem "rubocop-performance", "~>1.6.0"
-gem "rubocop-rails", "~>2.6.0"
 
 # pagination
 gem "kaminari", "~> 1.2.0"
@@ -39,6 +32,8 @@ gem "kaminari", "~> 1.2.0"
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
+
+  gem "awesome_print"
 end
 
 group :development do
@@ -48,6 +43,11 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
+
+  # code formatter
+  gem "rubocop", "~> 0.85.0"
+  gem "rubocop-performance", "~>1.6.0"
+  gem "rubocop-rails", "~>2.6.0"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,18 @@ GEM
     image_processing (1.11.0)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -242,6 +254,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   carrierwave
+  kaminari (~> 1.2.0)
   listen (>= 3.0.5, < 3.2)
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.1)

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,7 +5,7 @@ class BooksController < ApplicationController
 
   # GET /books
   def index
-    @books = Book.all
+    @books = Book.all.page(params[:page])
   end
 
   # GET /books/1

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -28,6 +28,8 @@
   </tbody>
 </table>
 
+<%= paginate @books %>
+
 <br>
 
 <%= link_to t('view.book.link.new'), new_book_path %>

--- a/config/locales/default/kaminari_en.yml
+++ b/config/locales/default/kaminari_en.yml
@@ -1,0 +1,8 @@
+en:
+  views:
+    pagination:
+      first: "« First"
+      last: "Last »"
+      previous: "‹ Prev"
+      next: "Next ›"
+      truncate: "…"

--- a/config/locales/default/kaminari_ja.yml
+++ b/config/locales/default/kaminari_ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "« 最初"
+      last: "最後 »"
+      previous: "‹ 前"
+      next: "次 ›"
+      truncate: "…"


### PR DESCRIPTION
## 概要
- kaminariを導入
- 書籍一覧ページにページング処理を追加
  - 1ページあたり25件

## UI
`localhost:3000/books`
||before|after|
| --- | --- | --- |
| 1ページ目 | ![image](https://user-images.githubusercontent.com/54785890/85724221-f7ae5f00-b72e-11ea-9f10-05ee52055950.png) | ![image](https://user-images.githubusercontent.com/54785890/85732639-807cc900-b736-11ea-8ee5-06ebebcde27e.png) |
| 2ページ目 | （存在しない） | ![image](https://user-images.githubusercontent.com/54785890/85732721-925e6c00-b736-11ea-81dc-24c79dc5cbbb.png) |

### 3ページ以上存在する場合
![image](https://user-images.githubusercontent.com/54785890/85732916-b8840c00-b736-11ea-9d0d-671312bb9a8a.png)
